### PR TITLE
show notification popup in the center of the screen

### DIFF
--- a/Core/Support/Notification/Notification.java
+++ b/Core/Support/Notification/Notification.java
@@ -29,7 +29,7 @@ public class Notification{
         JDialog d =  a.createDialog(null);
         Width = GetWidht();
         Height = GetHight();
-        d.setLocation(Width,Height);
+        d.setLocation(Width / 2, Height / 2);
         d.setVisible(true);
         d.setTitle("MR.HOLMES");
         d.setResizable(false);


### PR DESCRIPTION
After a Scan of e.g. a Username, eventually, there will be the response `REPORT WRITTEN IN: GUI/Reports/Usernames/<search_term>/<search_term>.txt`.

In order to proceed, one has to dismiss a popup. This popup is hidden extremely well: At the bottom right corner of the screen. Here's my bottom right edge of the screen. The popup is hidden behind the task bar:
![screen](https://github.com/Lucksi/Mr.Holmes/assets/74609327/7a027293-eb45-4888-a6cf-8322f7a2686e)

Took me quite a while to figure that out.

Reason is simple: You create the popup by getting screen width and height and moving the popup to that position. To solve this issue, just divide those values by two, to position the popup near the center of the screen.