### PR TITLE
fix: add User-Agent header to Nominatim requests (fixes 403 Forbidden)

### DIFF
--- a/Core/Support/Phone/Numbers.py
+++ b/Core/Support/Phone/Numbers.py
@@ -23,8 +23,10 @@ class Phony:
 
     @staticmethod
     def Get_GeoLocation(zone, param1, param2, jsonfile, num, Type):
-        req = "https://nominatim.openstreetmap.org/search.php?q={}&format=json".format(
-            zone)
+        req = urllib.request.Request(
+                "https://nominatim.openstreetmap.org/search.php?q={}&format=json".format(zone),
+                headers={"User-Agent": "MrHolmes-OSINT/1.0"}
+            )
         print(Font.Color.GREEN + "\n[+]" + Font.Color.WHITE +
               Language.Translation.Translate_Language(filename, "Phone", "Geo", "None").format(num))
         sleep(2)


### PR DESCRIPTION
Nominatim was giving 403 Forbidden because the request was not including the User-Agent.

**Fix:** Changed urlopen(string) with urlopen(Request(..., headers={"User-Agent": ...})).